### PR TITLE
Upgrade to Kubernetes 1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 18.0.0+1.22.5
+
+- update `k8s_release` to `1.22.5`
+- default the `cgroupDriver` value in the `KubeletConfiguration` to `systemd` as `kubelet` runs as a `systemd` service. See [configure-cgroup-driver](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/) for more details. Before that the default was `cgroupfs`. Also see [Migrating to the systemd driver](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/#migrating-to-the-systemd-driver)
+
 ## 17.0.0+1.21.8
 
 - **BREAKING**: This role no longer installs `CNI plugins`. So the variables `k8s_cni_dir`, `k8s_cni_bin_dir`, `k8s_cni_conf_dir`, `k8s_cni_plugin_version` and `k8s_cni_plugin_checksum` are no longer relevant and are ignored. Please use Ansible role [containerd](https://galaxy.ansible.com/githubixx/containerd) to install `containerd`, `runc` and `CNI plugins` before installing this role. Also see [Kubernetes: Replace dockershim with containerd and runc](https://www.tauceti.blog/posts/kubernetes-replace-docker-with-containerd-runc/)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ k8s_conf_dir: "/var/lib/kubernetes"
 k8s_bin_dir: "/usr/local/bin"
 
 # K8s release
-k8s_release: "1.21.8"
+k8s_release: "1.22.5"
 
 # The interface on which the K8s services should listen on. As all cluster
 # communication should use a VPN interface the interface name is

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ k8s_worker_kubelet_settings:
   "kubeconfig": "{{k8s_worker_kubelet_conf_dir}}/kubeconfig"
   "register-node": "true"
 
-# kublet kubeconfig
+# kubelet kubeconfig
 k8s_worker_kubelet_conf_yaml: |
   kind: KubeletConfiguration
   apiVersion: kubelet.config.k8s.io/v1beta1

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ k8s_worker_kubelet_conf_yaml: |
   serializeImagePulls: false
   tlsCertFile: "{{k8s_conf_dir}}/cert-{{inventory_hostname}}.pem"
   tlsPrivateKeyFile: "{{k8s_conf_dir}}/cert-{{inventory_hostname}}-key.pem"
+  cgroupDriver: "systemd"
 
 # Directory to store kube-proxy configuration
 k8s_worker_kubeproxy_conf_dir: "/var/lib/kube-proxy"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ k8s_conf_dir: "/var/lib/kubernetes"
 k8s_bin_dir: "/usr/local/bin"
 
 # K8s release
-k8s_release: "1.21.8"
+k8s_release: "1.22.5"
 
 # The interface on which the K8s services should listen on. As all cluster
 # communication should use a VPN interface the interface name is

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,6 +77,7 @@ k8s_worker_kubelet_conf_yaml: |
   serializeImagePulls: false
   tlsCertFile: "{{k8s_conf_dir}}/cert-{{inventory_hostname}}.pem"
   tlsPrivateKeyFile: "{{k8s_conf_dir}}/cert-{{inventory_hostname}}-key.pem"
+  cgroupDriver: "systemd"
 
 # Directory to store kube-proxy configuration
 k8s_worker_kubeproxy_conf_dir: "/var/lib/kube-proxy"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,7 +53,7 @@ k8s_worker_kubelet_settings:
   "kubeconfig": "{{k8s_worker_kubelet_conf_dir}}/kubeconfig"
   "register-node": "true"
 
-# kublet kubeconfig
+# kubelet kubeconfig
 k8s_worker_kubelet_conf_yaml: |
   kind: KubeletConfiguration
   apiVersion: kubelet.config.k8s.io/v1beta1


### PR DESCRIPTION
- update `k8s_release` to `1.22.5`
- default the `cgroupDriver` value in the `KubeletConfiguration` to `systemd` as `kubelet` runs as a `systemd` service. See [configure-cgroup-driver](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/) for more details. Before that the default was `cgroupfs`. Also see [Migrating to the systemd driver](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/#migrating-to-the-systemd-driver)