### PR TITLE
21.1.0+1.25.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `tasks/main.yml`: add `changed_when: false` to `Disable swap` task
 - `tasks/main.yml`: use `ansible.posix.mount` instead of `ansible.builtin.mount`
 - `kubelet`: remove `--container-runtime` (Flag `--container-runtime` has been deprecated, will be removed in 1.27 as the only valid value is `remote`)
+- `kubelet`: update information about `seccomp-default` / remove `SeccompDefault` feature gate (now beta and enabled by default)
 
 ## 21.0.0+1.25.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 21.1.0+1.25.9
+
+update `k8s_release` to `1.25.9`
+
 ## 21.0.0+1.25.5
 
 update `k8s_release` to `1.25.5`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,19 @@
 
 ## 21.1.0+1.25.9
 
-update `k8s_release` to `1.25.9`
+- update `k8s_release` to `1.25.9`
+- move kubelet parameter `--register-node` to `kubelet.conf` (using the option as parameter is deprected)
+- `tasks/main.yml`: add `changed_when: false` to `Disable swap` task
+- `tasks/main.yml`: use `ansible.posix.mount` instead of `ansible.builtin.mount`
+- `kubelet`: remove `--container-runtime` (Flag `--container-runtime` has been deprecated, will be removed in 1.27 as the only valid value is `remote`)
 
 ## 21.0.0+1.25.5
 
-update `k8s_release` to `1.25.5`
+- update `k8s_release` to `1.25.5`
 
 ## 20.0.1+1.24.9
 
-update `k8s_release` to `1.24.9`
+- update `k8s_release` to `1.24.9`
 
 ## 20.0.0+1.24.4
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Role Variables
 --------------
 
 ```yaml
+---
 # The directory to store the K8s certificates and other configuration
 k8s_conf_dir: "/var/lib/kubernetes"
 
@@ -77,38 +78,40 @@ k8s_worker_kubelet_conf_dir: "/var/lib/kubelet"
 # "feature-gates": "SeccompDefault=true"
 # "seccomp-default": ""
 #
+# These settings are Beta but may be worth adding. Also see:
+# https://kubernetes.io/docs/tutorials/security/seccomp/#enable-the-use-of-runtimedefault-as-the-default-seccomp-profile-for-all-workloads
+#
 k8s_worker_kubelet_settings:
-  "config": "{{k8s_worker_kubelet_conf_dir}}/kubelet-config.yaml"
-  "node-ip": "{{hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address}}"
-  "container-runtime": "remote"
+  "config": "{{ k8s_worker_kubelet_conf_dir }}/kubelet-config.yaml"
+  "node-ip": "{{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}"
   "container-runtime-endpoint": "unix:///run/containerd/containerd.sock"
-  "kubeconfig": "{{k8s_worker_kubelet_conf_dir}}/kubeconfig"
+  "kubeconfig": "{{ k8s_worker_kubelet_conf_dir }}/kubeconfig"
   "register-node": "true"
 
 # kubelet kubeconfig
 k8s_worker_kubelet_conf_yaml: |
   kind: KubeletConfiguration
   apiVersion: kubelet.config.k8s.io/v1beta1
-  address: {{hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address}}
+  address: {{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}
   authentication:
     anonymous:
       enabled: false
     webhook:
       enabled: true
     x509:
-      clientCAFile: "{{k8s_conf_dir}}/ca-k8s-apiserver.pem"
+      clientCAFile: "{{ k8s_conf_dir }}/ca-k8s-apiserver.pem"
   authorization:
     mode: Webhook
   clusterDomain: "cluster.local"
   clusterDNS:
     - "10.32.0.254"
   failSwapOn: true
-  healthzBindAddress: "{{hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address}}"
+  healthzBindAddress: "{{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}"
   healthzPort: 10248
   runtimeRequestTimeout: "15m"
   serializeImagePulls: false
-  tlsCertFile: "{{k8s_conf_dir}}/cert-{{inventory_hostname}}.pem"
-  tlsPrivateKeyFile: "{{k8s_conf_dir}}/cert-{{inventory_hostname}}-key.pem"
+  tlsCertFile: "{{ k8s_conf_dir }}/cert-{{ inventory_hostname }}.pem"
+  tlsPrivateKeyFile: "{{ k8s_conf_dir }}/cert-{{ inventory_hostname }}-key.pem"
   cgroupDriver: "systemd"
 
 # Directory to store kube-proxy configuration
@@ -116,15 +119,15 @@ k8s_worker_kubeproxy_conf_dir: "/var/lib/kube-proxy"
 
 # kube-proxy settings
 k8s_worker_kubeproxy_settings:
-  "config": "{{k8s_worker_kubeproxy_conf_dir}}/kubeproxy-config.yaml"
+  "config": "{{ k8s_worker_kubeproxy_conf_dir }}/kubeproxy-config.yaml"
 
 k8s_worker_kubeproxy_conf_yaml: |
   kind: KubeProxyConfiguration
   apiVersion: kubeproxy.config.k8s.io/v1alpha1
-  bindAddress: {{hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address}}
+  bindAddress: {{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}
   clientConnection:
-    kubeconfig: "{{k8s_worker_kubeproxy_conf_dir}}/kubeconfig"
-  healthzBindAddress: {{hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address}}:10256
+    kubeconfig: "{{ k8s_worker_kubeproxy_conf_dir }}/kubeconfig"
+  healthzBindAddress: {{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}:10256
   mode: "ipvs"
   ipvs:
     minSyncPeriod: 0s

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ k8s_conf_dir: "/var/lib/kubernetes"
 k8s_bin_dir: "/usr/local/bin"
 
 # K8s release
-k8s_release: "1.25.5"
+k8s_release: "1.25.9"
 
 # The interface on which the K8s services should listen on. As all cluster
 # communication should use a VPN interface the interface name is

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ k8s_worker_kubelet_settings:
   "node-ip": "{{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}"
   "container-runtime-endpoint": "unix:///run/containerd/containerd.sock"
   "kubeconfig": "{{ k8s_worker_kubelet_conf_dir }}/kubeconfig"
-  "register-node": "true"
 
 # kubelet kubeconfig
 k8s_worker_kubelet_conf_yaml: |
@@ -113,6 +112,7 @@ k8s_worker_kubelet_conf_yaml: |
   tlsCertFile: "{{ k8s_conf_dir }}/cert-{{ inventory_hostname }}.pem"
   tlsPrivateKeyFile: "{{ k8s_conf_dir }}/cert-{{ inventory_hostname }}-key.pem"
   cgroupDriver: "systemd"
+  registerNode: true
 
 # Directory to store kube-proxy configuration
 k8s_worker_kubeproxy_conf_dir: "/var/lib/kube-proxy"

--- a/README.md
+++ b/README.md
@@ -71,16 +71,14 @@ k8s_worker_download_dir: "/opt/tmp"
 k8s_worker_kubelet_conf_dir: "/var/lib/kubelet"
 
 # kubelet settings
-#
+# 
 # If you want to enable the use of "RuntimeDefault" as the default seccomp
-# profile for all workloads add these settings:
-#
-# "feature-gates": "SeccompDefault=true"
+# profile for all workloads add these settings to "k8s_worker_kubelet_settings":
+# 
 # "seccomp-default": ""
 #
-# These settings are Beta but may be worth adding. Also see:
+# Also see:
 # https://kubernetes.io/docs/tutorials/security/seccomp/#enable-the-use-of-runtimedefault-as-the-default-seccomp-profile-for-all-workloads
-#
 k8s_worker_kubelet_settings:
   "config": "{{ k8s_worker_kubelet_conf_dir }}/kubelet-config.yaml"
   "node-ip": "{{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,14 +47,12 @@ k8s_worker_kubelet_conf_dir: "/var/lib/kubelet"
 # kubelet settings
 #
 # If you want to enable the use of "RuntimeDefault" as the default seccomp
-# profile for all workloads add these settings:
+# profile for all workloads add these settings to "k8s_worker_kubelet_settings":
 #
-# "feature-gates": "SeccompDefault=true"
 # "seccomp-default": ""
 #
-# These settings are Beta but may be worth adding. Also see:
+# Also see:
 # https://kubernetes.io/docs/tutorials/security/seccomp/#enable-the-use-of-runtimedefault-as-the-default-seccomp-profile-for-all-workloads
-#
 k8s_worker_kubelet_settings:
   "config": "{{ k8s_worker_kubelet_conf_dir }}/kubelet-config.yaml"
   "node-ip": "{{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}"
@@ -87,8 +85,6 @@ k8s_worker_kubelet_conf_yaml: |
   tlsPrivateKeyFile: "{{ k8s_conf_dir }}/cert-{{ inventory_hostname }}-key.pem"
   cgroupDriver: "systemd"
   registerNode: true
-  featureGates:
-    SeccompDefault: true
 
 # Directory to store kube-proxy configuration
 k8s_worker_kubeproxy_conf_dir: "/var/lib/kube-proxy"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ k8s_conf_dir: "/var/lib/kubernetes"
 k8s_bin_dir: "/usr/local/bin"
 
 # K8s release
-k8s_release: "1.25.5"
+k8s_release: "1.25.9"
 
 # The interface on which the K8s services should listen on. As all cluster
 # communication should use a VPN interface the interface name is

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,7 +60,6 @@ k8s_worker_kubelet_settings:
   "node-ip": "{{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}"
   "container-runtime-endpoint": "unix:///run/containerd/containerd.sock"
   "kubeconfig": "{{ k8s_worker_kubelet_conf_dir }}/kubeconfig"
-  "register-node": "true"
 
 # kubelet kubeconfig
 k8s_worker_kubelet_conf_yaml: |
@@ -87,6 +86,9 @@ k8s_worker_kubelet_conf_yaml: |
   tlsCertFile: "{{ k8s_conf_dir }}/cert-{{ inventory_hostname }}.pem"
   tlsPrivateKeyFile: "{{ k8s_conf_dir }}/cert-{{ inventory_hostname }}-key.pem"
   cgroupDriver: "systemd"
+  registerNode: true
+  featureGates:
+    SeccompDefault: true
 
 # Directory to store kube-proxy configuration
 k8s_worker_kubeproxy_conf_dir: "/var/lib/kube-proxy"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,7 +58,6 @@ k8s_worker_kubelet_conf_dir: "/var/lib/kubelet"
 k8s_worker_kubelet_settings:
   "config": "{{ k8s_worker_kubelet_conf_dir }}/kubelet-config.yaml"
   "node-ip": "{{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}"
-  "container-runtime": "remote"
   "container-runtime-endpoint": "unix:///run/containerd/containerd.sock"
   "kubeconfig": "{{ k8s_worker_kubelet_conf_dir }}/kubeconfig"
   "register-node": "true"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,7 @@
 - name: Disable swap
   ansible.builtin.command: swapoff -a
   when: ansible_swaptotal_mb > 0
+  changed_when: false
   tags:
     - k8s-worker
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Remove swapfile from /etc/fstab
-  ansible.builtin.mount:
+  ansible.posix.mount:
     name: swap
     fstype: swap
     state: absent


### PR DESCRIPTION
- update `k8s_release` to `1.25.9`
- move kubelet parameter `--register-node` to `kubelet.conf` (using the option as parameter is deprected)
- `tasks/main.yml`: add `changed_when: false` to `Disable swap` task
- `tasks/main.yml`: use `ansible.posix.mount` instead of `ansible.builtin.mount`
- `kubelet`: remove `--container-runtime` (Flag `--container-runtime` has been deprecated, will be removed in 1.27 as the only valid value is `remote`)
- `kubelet`: update information about `seccomp-default` / remove `SeccompDefault` feature gate (now beta and enabled by default)