### PR TITLE
22.0.1+1.26.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 22.0.1+1.26.8
+
+- update `k8s_release` to `1.26.8`
+
 ## 22.0.0+1.26.4
 
 - update `k8s_release` to `1.26.4`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 22.0.1+1.26.8
 
 - update `k8s_release` to `1.26.8`
+- `kube-proxy` needs to have network-online.target ready
+- `kubelet` needs to have network-online.target ready
 
 ## 22.0.0+1.26.4
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ k8s_conf_dir: "/var/lib/kubernetes"
 k8s_bin_dir: "/usr/local/bin"
 
 # K8s release
-k8s_release: "1.26.4"
+k8s_release: "1.26.8"
 
 # The interface on which the K8s services should listen on. As all cluster
 # communication should use a VPN interface the interface name is

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ k8s_conf_dir: "/var/lib/kubernetes"
 k8s_bin_dir: "/usr/local/bin"
 
 # K8s release
-k8s_release: "1.26.4"
+k8s_release: "1.26.8"
 
 # The interface on which the K8s services should listen on. As all cluster
 # communication should use a VPN interface the interface name is

--- a/templates/etc/systemd/system/kube-proxy.service.j2
+++ b/templates/etc/systemd/system/kube-proxy.service.j2
@@ -2,6 +2,8 @@
 [Unit]
 Description=Kubernetes Kube Proxy
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 ExecStart={{k8s_bin_dir}}/kube-proxy \

--- a/templates/etc/systemd/system/kubelet.service.j2
+++ b/templates/etc/systemd/system/kubelet.service.j2
@@ -2,8 +2,10 @@
 [Unit]
 Description=Kubernetes Kubelet
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+After=network-online.target
 After=containerd.service
 Requires=containerd.service
+Wants=network-online.target
 
 [Service]
 ExecStart={{k8s_bin_dir}}/kubelet \


### PR DESCRIPTION
- update `k8s_release` to `1.26.8`
- [kube-proxy needs to have network-online.target ready](https://github.com/githubixx/ansible-role-kubernetes-worker/commit/96c245202c83fc5ef4ec0347707449f5e30d0cd8)
- [kubelet needs to have network-online.target ready](https://github.com/githubixx/ansible-role-kubernetes-worker/commit/93c59415e932212482255b80fe4fa81ee9d75455)