### PR TITLE
23.0.0+1.27.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 23.0.0+1.27.5
 
 - **BREAKING**: `meta/main.yml`: change role_name from `kubernetes-worker` to `kubernetes_worker`. This is a requirement since quite some time for Ansible Galaxy. But the requirement was introduced after this role already existed for quite some time. So please update the name of the role in your playbook accordingly!
+- rename `kubernetes-controller` to `kubernetes_controller` as role name changed (requirement as before)
 - update `k8s_release` to `1.27.5`
 - moved `container-runtime-endpoint` setting from `k8s_worker_kubelet_settings` variable (`/etc/systemd/system/kubelet.service`) to `k8s_worker_kubelet_conf_yaml` variable (`kubelet-config.yaml`). The name changed from `container-runtime-endpoint` to `containerRuntimeEndpoint`. For more information see pull request [kubelet: migrate container runtime endpoint flag to config](https://github.com/kubernetes/kubernetes/pull/112136).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 23.0.0+1.27.5
+
+- update `k8s_release` to `1.27.5`
+
 ## 22.0.1+1.26.8
 
 - update `k8s_release` to `1.26.8`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 23.0.0+1.27.5
 
 - update `k8s_release` to `1.27.5`
+- moved `container-runtime-endpoint` setting from `k8s_worker_kubelet_settings` variable (`/etc/systemd/system/kubelet.service`) to `k8s_worker_kubelet_conf_yaml` variable (`kubelet-config.yaml`). The name changed from `container-runtime-endpoint` to `containerRuntimeEndpoint`. For more information see pull request [kubelet: migrate container runtime endpoint flag to config](https://github.com/kubernetes/kubernetes/pull/112136).
 
 ## 22.0.1+1.26.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 23.0.0+1.27.5
 
+- **BREAKING**: `meta/main.yml`: change role_name from `kubernetes-worker` to `kubernetes_worker`. This is a requirement since quite some time for Ansible Galaxy. But the requirement was introduced after this role already existed for quite some time. So please update the name of the role in your playbook accordingly!
 - update `k8s_release` to `1.27.5`
 - moved `container-runtime-endpoint` setting from `k8s_worker_kubelet_settings` variable (`/etc/systemd/system/kubelet.service`) to `k8s_worker_kubelet_conf_yaml` variable (`kubelet-config.yaml`). The name changed from `container-runtime-endpoint` to `containerRuntimeEndpoint`. For more information see pull request [kubelet: migrate container runtime endpoint flag to config](https://github.com/kubernetes/kubernetes/pull/112136).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - update `k8s_release` to `1.27.5`
 - `meta/main.yml`: remove Ubuntu 18.04 as supported OS (reached EOL)
 - moved `container-runtime-endpoint` setting from `k8s_worker_kubelet_settings` variable (`/etc/systemd/system/kubelet.service`) to `k8s_worker_kubelet_conf_yaml` variable (`kubelet-config.yaml`). The name changed from `container-runtime-endpoint` to `containerRuntimeEndpoint`. For more information see pull request [kubelet: migrate container runtime endpoint flag to config](https://github.com/kubernetes/kubernetes/pull/112136).
+- remove `Install some network packages` task for Red Hat based OSes (was actually never officially supported)
 
 ## 22.0.1+1.26.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **BREAKING**: `meta/main.yml`: change role_name from `kubernetes-worker` to `kubernetes_worker`. This is a requirement since quite some time for Ansible Galaxy. But the requirement was introduced after this role already existed for quite some time. So please update the name of the role in your playbook accordingly!
 - rename `kubernetes-controller` to `kubernetes_controller` as role name changed (requirement as before)
 - update `k8s_release` to `1.27.5`
+- `meta/main.yml`: remove Ubuntu 18.04 as supported OS (reached EOL)
 - moved `container-runtime-endpoint` setting from `k8s_worker_kubelet_settings` variable (`/etc/systemd/system/kubelet.service`) to `k8s_worker_kubelet_conf_yaml` variable (`kubelet-config.yaml`). The name changed from `container-runtime-endpoint` to `containerRuntimeEndpoint`. For more information see pull request [kubelet: migrate container runtime endpoint flag to config](https://github.com/kubernetes/kubernetes/pull/112136).
 
 ## 22.0.1+1.26.8

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Example Playbook
 ```yaml
 - hosts: k8s_worker
   roles:
-    - githubixx.kubernetes-worker
+    - githubixx.kubernetes_worker
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ k8s_conf_dir: "/var/lib/kubernetes"
 k8s_bin_dir: "/usr/local/bin"
 
 # K8s release
-k8s_release: "1.26.8"
+k8s_release: "1.27.5"
 
 # The interface on which the K8s services should listen on. As all cluster
 # communication should use a VPN interface the interface name is

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ k8s_worker_kubeproxy_conf_yaml: |
 Dependencies
 ------------
 
-- [kubernetes-controller](https://galaxy.ansible.com/githubixx/kubernetes-controller/)
+- [kubernetes_controller](https://galaxy.ansible.com/githubixx/kubernetes_controller/)
 - [containerd](https://galaxy.ansible.com/githubixx/containerd)
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ k8s_conf_dir: "/var/lib/kubernetes"
 k8s_bin_dir: "/usr/local/bin"
 
 # K8s release
-k8s_release: "1.26.8"
+k8s_release: "1.27.5"
 
 # The interface on which the K8s services should listen on. As all cluster
 # communication should use a VPN interface the interface name is

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,7 +56,6 @@ k8s_worker_kubelet_conf_dir: "/var/lib/kubelet"
 k8s_worker_kubelet_settings:
   "config": "{{ k8s_worker_kubelet_conf_dir }}/kubelet-config.yaml"
   "node-ip": "{{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}"
-  "container-runtime-endpoint": "unix:///run/containerd/containerd.sock"
   "kubeconfig": "{{ k8s_worker_kubelet_conf_dir }}/kubeconfig"
 
 # kubelet kubeconfig
@@ -85,6 +84,7 @@ k8s_worker_kubelet_conf_yaml: |
   tlsPrivateKeyFile: "{{ k8s_conf_dir }}/cert-{{ inventory_hostname }}-key.pem"
   cgroupDriver: "systemd"
   registerNode: true
+  containerRuntimeEndpoint: "unix:///run/containerd/containerd.sock"
 
 # Directory to store kube-proxy configuration
 k8s_worker_kubeproxy_conf_dir: "/var/lib/kube-proxy"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Installs Kubernetes worker.
   license: GPLv3
   min_ansible_version: "2.9"
-  role_name: kubernetes-worker
+  role_name: kubernetes_worker
   namespace: githubixx
   platforms:
     - name: Ubuntu

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - focal
+        - "focal"
   galaxy_tags:
     - kubernetes
     - worker

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - bionic
         - focal
   galaxy_tags:
     - kubernetes

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -11,7 +11,7 @@
       when:
         - k8s_worker_setup_networking is not defined
       ansible.builtin.include_role:
-        name: githubixx.kubernetes-worker
+        name: githubixx.kubernetes_worker
 
 - name: Setup Cilium
   hosts: k8s_worker

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -133,9 +133,9 @@
   become: true
   gather_facts: true
   tasks:
-    - name: Include kubernetes-controller role
+    - name: Include kubernetes_controller role
       ansible.builtin.include_role:
-        name: githubixx.kubernetes-controller
+        name: githubixx.kuberneter_controller
 
 - name: Setup containerd
   hosts: k8s_worker

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -10,7 +10,7 @@ roles:
   - githubixx.kubernetes-ca
   - githubixx.etcd
   - githubixx.kubectl
-  - githubixx.kubernetes-controller
+  - githubixx.kubernetes_controller
   - githubixx.kubernetes_worker
   - githubixx.containerd
   - githubixx.cilium_kubernetes

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -11,6 +11,6 @@ roles:
   - githubixx.etcd
   - githubixx.kubectl
   - githubixx.kubernetes-controller
-  - githubixx.kubernetes-worker
+  - githubixx.kubernetes_worker
   - githubixx.containerd
   - githubixx.cilium_kubernetes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,15 +58,6 @@
     pkg: ['ebtables', 'ethtool', 'ipset', 'conntrack', 'iptables', 'iptstate', 'netstat-nat', 'socat', 'netbase']
   tags:
     - k8s-worker
-  when: ansible_os_family == "Debian"
-
-- name: Install some network packages
-  ansible.builtin.yum:
-    state: present
-    name: ['ebtables', 'ethtool', 'ipset', 'conntrack', 'iptables', 'iptstate', 'net-tools']
-  tags:
-    - k8s-worker
-  when: ansible_os_family == "RedHat"
 
 - name: Copy worker certificates (part 1)
   ansible.builtin.copy:


### PR DESCRIPTION
- **BREAKING**: `meta/main.yml`: change role_name from `kubernetes-worker` to `kubernetes_worker`. This is a requirement since quite some time for Ansible Galaxy. But the requirement was introduced after this role already existed for quite some time. So please update the name of the role in your playbook accordingly!
- rename `kubernetes-controller` to `kubernetes_controller` as role name changed (requirement as before)
- update `k8s_release` to `1.27.5`
- `meta/main.yml`: remove Ubuntu 18.04 as supported OS (reached EOL)
- moved `container-runtime-endpoint` setting from `k8s_worker_kubelet_settings` variable (`/etc/systemd/system/kubelet.service`) to `k8s_worker_kubelet_conf_yaml` variable (`kubelet-config.yaml`). The name changed from `container-runtime-endpoint` to `containerRuntimeEndpoint`. For more information see pull request [kubelet: migrate container runtime endpoint flag to config](https://github.com/kubernetes/kubernetes/pull/112136).
- remove `Install some network packages` task for Red Hat based OSes (was actually never officially supported)