### PR TITLE
23.1.0+1.27.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 23.1.0+1.27.5
+
+- add support for Ubuntu 22.04
+- `molecule/default/group_vars/all.yml`: Removed `container-runtime-endpoint` setting from `k8s_worker_kubelet_settings` (/etc/systemd/system/kubelet.service). It was moved to `k8s_worker_kubelet_conf_yaml` (kubelet-config.yaml)
+
 ## 23.0.0+1.27.5
 
 - **BREAKING**: `meta/main.yml`: change role_name from `kubernetes-worker` to `kubernetes_worker`. This is a requirement since quite some time for Ansible Galaxy. But the requirement was introduced after this role already existed for quite some time. So please update the name of the role in your playbook accordingly!

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,6 +10,7 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - "focal"
+        - "jammy"
   galaxy_tags:
     - kubernetes
     - worker

--- a/molecule/default/group_vars/all.yml
+++ b/molecule/default/group_vars/all.yml
@@ -125,7 +125,6 @@ k8s_apiserver_settings_user:
 k8s_worker_kubelet_settings:
   "config": "{{k8s_worker_kubelet_conf_dir}}/kubelet-config.yaml"
   "node-ip": "{{hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address}}"
-  "container-runtime-endpoint": "unix:///run/containerd/containerd.sock"
   "kubeconfig": "{{k8s_worker_kubelet_conf_dir}}/kubeconfig"
   "seccomp-default": ""
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -15,7 +15,7 @@ driver:
 
 platforms:
   - name: test-assets
-    box: generic/ubuntu2204
+    box: generic/ubuntu2004
     memory: 2048
     cpus: 2
     groups:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -15,8 +15,8 @@ driver:
 
 platforms:
   - name: test-assets
-    box: generic/ubuntu2004
-    memory: 1024
+    box: generic/ubuntu2204
+    memory: 2048
     cpus: 2
     groups:
       - vpn
@@ -28,7 +28,7 @@ platforms:
         type: static
         ip: 192.168.10.5
   - name: test-controller1
-    box: generic/ubuntu2004
+    box: generic/ubuntu2204
     memory: 2048
     cpus: 2
     groups:
@@ -43,7 +43,7 @@ platforms:
         type: static
         ip: 192.168.10.10
   - name: test-controller2
-    box: generic/ubuntu2004
+    box: generic/ubuntu2204
     memory: 2048
     cpus: 2
     groups:
@@ -73,7 +73,7 @@ platforms:
         type: static
         ip: 192.168.10.30
   - name: test-worker1
-    box: generic/ubuntu2004
+    box: generic/ubuntu2204
     memory: 2048
     cpus: 2
     groups:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -135,7 +135,7 @@
   tasks:
     - name: Include kubernetes_controller role
       ansible.builtin.include_role:
-        name: githubixx.kuberneter_controller
+        name: githubixx.kubernetes_controller
 
 - name: Setup containerd
   hosts: k8s_worker

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -9,7 +9,6 @@
       kubernetes.core.k8s_info:
         api_version: v1
         kind: namespace
-        validate_certs: false
       register: k8s__namespaces_info
 
     - name: Print namespaces

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -9,6 +9,7 @@
       kubernetes.core.k8s_info:
         api_version: v1
         kind: namespace
+        validate_certs: false
       register: k8s__namespaces_info
 
     - name: Print namespaces
@@ -24,7 +25,7 @@
       vars:
         query: "length(resources)"
 
-    - name: There should be four namespaces
+    - name: There should be four namespaces at least
       ansible.builtin.assert:
         that:
           - k8s__namespaces_count|int >= 4


### PR DESCRIPTION
- add support for Ubuntu 22.04
- `molecule/default/group_vars/all.yml`: Removed `container-runtime-endpoint` setting from `k8s_worker_kubelet_settings` (/etc/systemd/system/kubelet.service). It was moved to `k8s_worker_kubelet_conf_yaml` (kubelet-config.yaml)