### PR TITLE
25.0.0+1.28.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 
 defaults:
   run:
-    working-directory: 'githubixx.kubernetes-worker'
+    working-directory: 'githubixx.kubernetes_worker'
 
 jobs:
   release:
@@ -23,7 +23,7 @@ jobs:
       - name: Check out the codebase.
         uses: actions/checkout@v2
         with:
-          path: 'githubixx.kubernetes-worker'
+          path: 'githubixx.kubernetes_worker'
 
       - name: Set up Python 3.
         uses: actions/setup-python@v2
@@ -35,5 +35,4 @@ jobs:
 
       - name: Trigger a new import on Galaxy.
         run: >-
-          ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }}
-          $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)
+          ansible-galaxy role import --token ${{ secrets.GALAXY_API_KEY }} -vvvvvvvv --role-name=$(echo ${{ github.repository }} | cut -d/ -f2 | sed 's/ansible-role-//' | sed 's/-/_/') $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)

--- a/.yamllint
+++ b/.yamllint
@@ -3,7 +3,7 @@ extends: default
 
 rules:
   line-length:
-    max: 200
+    max: 300
     level: warning
 
   comments-indentation: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,14 @@ Version `24.0.0+1.27.8` had a lot of potential breaking changes. So if you upgra
 ### OTHER CHANGES
 
 - adjust Github action because of Ansible Galaxy changes
+- `.yamllint`: extend max line length from 200 to 300
 
 ### MOLECULE
 
 - change to Ubuntu 22.04 for test-assets VM
 - change IP addresses
 - adjust common names for certificates / change algo to ecdsa and algo size
+- remove `collections.yml"
 
 ## 24.0.0+1.27.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 25.0.0+1.28.5
+
+### PLEASE READ CAREFULLY
+
+Version `24.0.0+1.27.8` had a lot of potential breaking changes. So if you upgrade from a version < `24.0.0+1.27.8` please read the CHANGELOG of that version too!
+
+### UPDATE
+
+- update `k8s_release` to `1.28.5`
+
+### OTHER CHANGES
+
+- adjust Github action because of Ansible Galaxy changes
+
+### MOLECULE
+
+- change to Ubuntu 22.04 for test-assets VM
+- change IP addresses
+- adjust common names for certificates / change algo to ecdsa and algo size
+
 ## 24.0.0+1.27.8
 
 ### PLEASE READ CAREFULLY

--- a/README.md
+++ b/README.md
@@ -38,12 +38,14 @@ Version `24.0.0+1.27.8` had a lot of potential breaking changes. So if you upgra
 ### OTHER CHANGES
 
 - adjust Github action because of Ansible Galaxy changes
+- `.yamllint`: extend max line length from 200 to 300
 
 ### MOLECULE
 
 - change to Ubuntu 22.04 for test-assets VM
 - change IP addresses
 - adjust common names for certificates / change algo to ecdsa and algo size
+- remove `collections.yml"
 
 ## 24.0.0+1.27.8
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,26 @@ See full [CHANGELOG.md](https://github.com/githubixx/ansible-role-kubernetes-wor
 
 **Recent changes:**
 
+## 25.0.0+1.28.5
+
+### PLEASE READ CAREFULLY
+
+Version `24.0.0+1.27.8` had a lot of potential breaking changes. So if you upgrade from a version < `24.0.0+1.27.8` please read the CHANGELOG of that version too!
+
+### UPDATE
+
+- update `k8s_release` to `1.28.5`
+
+### OTHER CHANGES
+
+- adjust Github action because of Ansible Galaxy changes
+
+### MOLECULE
+
+- change to Ubuntu 22.04 for test-assets VM
+- change IP addresses
+- adjust common names for certificates / change algo to ecdsa and algo size
+
 ## 24.0.0+1.27.8
 
 ### PLEASE READ CAREFULLY
@@ -75,9 +95,24 @@ This refactoring was needed to make it possible to have `githubixx.kubernetes_co
 - Add tasks to install [ansible-role-cni](https://github.com/githubixx/ansible-role-cni) and [ansible-role-runc](https://github.com/githubixx/ansible-role-runc)
 - Use `kubernetes.core.k8s_info` module instead of calling `kubectl` binary
 
-## 23.1.2+1.27.5
+## Installation
 
-- rename `githubixx.harden-linux` to `githubixx.harden_linux`
+- Directly download from Github (Change into Ansible roles directory before cloning. You can figure out the role path by using `ansible-config dump | grep DEFAULT_ROLES_PATH` command):
+`git clone https://github.com/githubixx/ansible-role-kubernetes-worker.git githubixx.kubernetes_worker`
+
+- Via `ansible-galaxy` command and download directly from Ansible Galaxy:
+`ansible-galaxy install role githubixx.kubernetes_worker`
+
+- Create a `requirements.yml` file with the following content (this will download the role from Github) and install with
+`ansible-galaxy role install -r requirements.yml` (change `version` if needed):
+
+```yaml
+---
+roles:
+  - name: githubixx.kubernetes_worker
+    src: https://github.com/githubixx/ansible-role-kubernetes-worker.git
+    version: 25.0.0+1.28.5
+```
 
 ## Role Variables
 
@@ -254,7 +289,7 @@ k8s_worker_kubeproxy_conf_yaml: |
 
 This role has a small test setup that is created using [Molecule](https://github.com/ansible-community/molecule), libvirt (vagrant-libvirt) and QEMU/KVM. Please see my blog post [Testing Ansible roles with Molecule, libvirt (vagrant-libvirt) and QEMU/KVM](https://www.tauceti.blog/posts/testing-ansible-roles-with-molecule-libvirt-vagrant-qemu-kvm/) how to setup. The test configuration is [here](https://github.com/githubixx/ansible-role-kubernetes-worker/tree/master/molecule/default).
 
-Afterwards Molecule can be executed. This will setup a few virtual machines (VM) with supported Ubuntu OS and installs an Kubernetes cluster:
+Afterwards Molecule can be executed. This will setup a few virtual machines (VM) with supported Ubuntu OS and installs a Kubernetes cluster:
 
 ```bash
 molecule converge
@@ -265,6 +300,8 @@ At this time the cluster isn't fully functional as a network plugin is missing e
 ```bash
 molecule converge -- --extra-vars k8s_worker_setup_networking=install
 ```
+
+After this you basically have a fully functional Kubernetes cluster.
 
 A small verification step is also included:
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ k8s_worker_pki_dir: "{{ k8s_worker_conf_dir }}/pki"
 k8s_worker_bin_dir: "/usr/local/bin"
 
 # K8s release
-k8s_worker_release: "1.27.8"
+k8s_worker_release: "1.28.5"
 
 # The interface on which the Kubernetes services should listen on. As all cluster
 # communication should use a VPN interface the interface name is

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,7 @@ k8s_worker_pki_dir: "{{ k8s_worker_conf_dir }}/pki"
 k8s_worker_bin_dir: "/usr/local/bin"
 
 # K8s release
-k8s_worker_release: "1.27.8"
+k8s_worker_release: "1.28.5"
 
 # The interface on which the Kubernetes services should listen on. As all cluster
 # communication should use a VPN interface the interface name is

--- a/molecule/default/collections.yml
+++ b/molecule/default/collections.yml
@@ -1,7 +1,0 @@
----
-# Copyright (C) 2023 Robert Wimmer
-# SPDX-License-Identifier: GPL-3.0-or-later
-
-collections:
-  - ansible.posix
-  - kubernetes.core

--- a/molecule/default/group_vars/all.yml
+++ b/molecule/default/group_vars/all.yml
@@ -141,16 +141,48 @@ coredns_delegate_to: "test-assets"
 
 # Common name for "etcd" certificate authority certificates.
 ca_etcd_csr_cn: "etcd"
+ca_etcd_csr_key_algo: "ecdsa"
+ca_etcd_csr_key_size: "384"
 
 # Common name for "kube-apiserver" certificate authority certificate.
 ca_k8s_apiserver_csr_cn: "kubernetes"
+ca_k8s_apiserver_csr_key_algo: "ecdsa"
+ca_k8s_apiserver_csr_key_size: "384"
 
 # Common names for "etcd" server, peer and client certificates.
-etcd_server_csr_cn: "etcd"
-etcd_peer_csr_cn: "etcd"
-etcd_client_csr_cn_prefix: "etcd"
+etcd_server_csr_cn: "etcd-server"
+etcd_server_csr_key_algo: "ecdsa"
+etcd_server_csr_key_size: "384"
+
+etcd_peer_csr_cn: "etcd-peer"
+etcd_peer_csr_key_algo: "ecdsa"
+etcd_peer_csr_key_size: "384"
+
+etcd_client_csr_cn_prefix: "etcd-client"
+etcd_client_csr_key_algo: "ecdsa"
+etcd_client_csr_key_size: "384"
 
 # Common names for kube-apiserver, admin and kube-controller-manager certificates.
-k8s_apiserver_csr_cn: "kubernetes"
-k8s_admin_csr_cn: "admin"
-k8s_controller_manager_sa_csr_cn: "service-accounts"
+k8s_apiserver_csr_cn: "k8s-apiserver"
+k8s_apiserver_csr_key_algo: "ecdsa"
+k8s_apiserver_csr_key_size: "384"
+
+k8s_admin_csr_cn: "k8s-admin"
+k8s_admin_csr_key_algo: "ecdsa"
+k8s_admin_csr_key_size: "384"
+
+k8s_worker_csr_key_algo: "ecdsa"
+k8s_worker_csr_key_size: "384"
+
+k8s_controller_manager_csr_key_algo: "ecdsa"
+k8s_controller_manager_csr_key_size: "384"
+
+k8s_scheduler_csr_key_algo: "ecdsa"
+k8s_scheduler_csr_key_size: "384"
+
+k8s_controller_manager_sa_csr_cn: "k8s-service-accounts"
+k8s_controller_manager_sa_csr_key_algo: "ecdsa"
+k8s_controller_manager_sa_csr_key_size: "384"
+
+k8s_kube_proxy_csr_key_algo: "ecdsa"
+k8s_kube_proxy_csr_key_size: "384"

--- a/molecule/default/group_vars/all.yml
+++ b/molecule/default/group_vars/all.yml
@@ -60,15 +60,6 @@ etcd_settings_user:
 etcd_cert_hosts:
   - localhost
   - 127.0.0.1
-  - 192.168.10.100
-  - 192.168.10.110
-  - 192.168.10.120
-  - 10.10.10.100
-  - 10.10.10.110
-  - 10.10.10.120
-  - test-etcd1
-  - test-etcd2
-  - test-etcd3
 
 # Directory where the Kubernetes certificates are stored on the Ansible
 # controller host.

--- a/molecule/default/host_vars/test-assets.yml
+++ b/molecule/default/host_vars/test-assets.yml
@@ -5,4 +5,4 @@
 wireguard_address: "10.10.10.5/24"
 wireguard_port: 51820
 wireguard_persistent_keepalive: "30"
-wireguard_endpoint: "192.168.10.5"
+wireguard_endpoint: "172.16.10.5"

--- a/molecule/default/host_vars/test-controller1.yml
+++ b/molecule/default/host_vars/test-controller1.yml
@@ -5,7 +5,7 @@
 wireguard_address: "10.10.10.10/24"
 wireguard_port: 51820
 wireguard_persistent_keepalive: "30"
-wireguard_endpoint: "192.168.10.10"
+wireguard_endpoint: "172.16.10.10"
 
 ha_proxy_frontend_bind_address: "127.0.0.1"
 ha_proxy_frontend_port: "16443"

--- a/molecule/default/host_vars/test-controller2.yml
+++ b/molecule/default/host_vars/test-controller2.yml
@@ -5,7 +5,7 @@
 wireguard_address: "10.10.10.20/24"
 wireguard_port: 51820
 wireguard_persistent_keepalive: "30"
-wireguard_endpoint: "192.168.10.20"
+wireguard_endpoint: "172.16.10.20"
 
 ha_proxy_frontend_bind_address: "127.0.0.1"
 ha_proxy_frontend_port: "16443"

--- a/molecule/default/host_vars/test-controller3.yml
+++ b/molecule/default/host_vars/test-controller3.yml
@@ -5,4 +5,4 @@
 wireguard_address: "10.10.10.30/24"
 wireguard_port: 51820
 wireguard_persistent_keepalive: "30"
-wireguard_endpoint: "192.168.10.30"
+wireguard_endpoint: "172.16.10.30"

--- a/molecule/default/host_vars/test-etcd1.yml
+++ b/molecule/default/host_vars/test-etcd1.yml
@@ -5,4 +5,4 @@
 wireguard_address: "10.10.10.100/24"
 wireguard_port: 51820
 wireguard_persistent_keepalive: "30"
-wireguard_endpoint: "192.168.10.100"
+wireguard_endpoint: "172.16.10.100"

--- a/molecule/default/host_vars/test-etcd2.yml
+++ b/molecule/default/host_vars/test-etcd2.yml
@@ -5,4 +5,4 @@
 wireguard_address: "10.10.10.110/24"
 wireguard_port: 51820
 wireguard_persistent_keepalive: "30"
-wireguard_endpoint: "192.168.10.110"
+wireguard_endpoint: "172.16.10.110"

--- a/molecule/default/host_vars/test-etcd3.yml
+++ b/molecule/default/host_vars/test-etcd3.yml
@@ -5,4 +5,4 @@
 wireguard_address: "10.10.10.120/24"
 wireguard_port: 51820
 wireguard_persistent_keepalive: "30"
-wireguard_endpoint: "192.168.10.120"
+wireguard_endpoint: "172.16.10.120"

--- a/molecule/default/host_vars/test-worker1.yml
+++ b/molecule/default/host_vars/test-worker1.yml
@@ -5,7 +5,7 @@
 wireguard_address: "10.10.10.200/24"
 wireguard_port: 51820
 wireguard_persistent_keepalive: "30"
-wireguard_endpoint: "192.168.10.200"
+wireguard_endpoint: "172.16.10.200"
 
 ha_proxy_frontend_bind_address: "127.0.0.1"
 ha_proxy_frontend_port: "16443"

--- a/molecule/default/host_vars/test-worker2.yml
+++ b/molecule/default/host_vars/test-worker2.yml
@@ -5,4 +5,4 @@
 wireguard_address: "10.10.10.210/24"
 wireguard_port: 51820
 wireguard_persistent_keepalive: "30"
-wireguard_endpoint: "192.168.10.210"
+wireguard_endpoint: "172.16.10.210"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,7 +13,7 @@ driver:
 
 platforms:
   - name: test-assets
-    box: generic/ubuntu2004
+    box: generic/ubuntu2204
     memory: 2048
     cpus: 2
     groups:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -24,7 +24,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.5
+        ip: 172.16.10.5
   - name: test-controller1
     box: generic/ubuntu2204
     memory: 2048
@@ -39,7 +39,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.10
+        ip: 172.16.10.10
   - name: test-controller2
     box: generic/ubuntu2204
     memory: 2048
@@ -54,7 +54,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.20
+        ip: 172.16.10.20
   - name: test-controller3
     box: generic/ubuntu2004
     memory: 2048
@@ -68,7 +68,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.30
+        ip: 172.16.10.30
   - name: test-etcd1
     box: generic/ubuntu2204
     memory: 2048
@@ -80,7 +80,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.100
+        ip: 172.16.10.100
   - name: test-etcd2
     box: generic/ubuntu2204
     memory: 2048
@@ -92,7 +92,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.110
+        ip: 172.16.10.110
   - name: test-etcd3
     box: generic/ubuntu2204
     memory: 2048
@@ -104,7 +104,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.120
+        ip: 172.16.10.120
   - name: test-worker1
     box: generic/ubuntu2204
     memory: 2048
@@ -118,7 +118,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.200
+        ip: 172.16.10.200
   - name: test-worker2
     box: generic/ubuntu2004
     memory: 2048
@@ -132,7 +132,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.210
+        ip: 172.16.10.210
 
 provisioner:
   name: ansible


### PR DESCRIPTION
### PLEASE READ CAREFULLY

Version `24.0.0+1.27.8` had a lot of potential breaking changes. So if you upgrade from a version < `24.0.0+1.27.8` please read the CHANGELOG of that version too!

### UPDATE

- update `k8s_release` to `1.28.5`

### OTHER CHANGES

- adjust Github action because of Ansible Galaxy changes
- `.yamllint`: extend max line length from 200 to 300

### MOLECULE

- change to Ubuntu 22.04 for test-assets VM
- change IP addresses
- adjust common names for certificates / change algo to ecdsa and algo size