### PR TITLE
26.0.2+1.29.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 26.0.2+1.29.9
+
+- **OTHER CHANGES**
+  - fix download URLs for Kubernetes binaries (see: [Download Kubernetes - Binaries](https://kubernetes.io/releases/download/#binaries)
+
 ## 26.0.1+1.29.9
 
 - **UPDATE**

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ See full [CHANGELOG.md](https://github.com/githubixx/ansible-role-kubernetes-wor
 
 **Recent changes:**
 
+## 26.0.2+1.29.9
+
+- **OTHER CHANGES**
+  - fix download URLs for Kubernetes binaries (see: [Download Kubernetes - Binaries](https://kubernetes.io/releases/download/#binaries)
+
 ## 26.0.1+1.29.9
 
 - **UPDATE**

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -98,8 +98,8 @@
 
 - name: Downloading official Kubernetes worker binaries
   ansible.builtin.get_url:
-    url: "https://storage.googleapis.com/kubernetes-release/release/v{{ k8s_worker_release }}/bin/linux/amd64/{{ item }}"
-    checksum: "sha512:https://storage.googleapis.com/kubernetes-release/release/v{{ k8s_worker_release }}/bin/linux/amd64/{{ item }}.sha512"
+    url: "https://dl.k8s.io/v{{ k8s_worker_release }}/bin/linux/amd64/{{ item }}"
+    checksum: "sha512:https://dl.k8s.io/v{{ k8s_worker_release }}/bin/linux/amd64/{{ item }}.sha512"
     dest: "{{ k8s_worker_bin_dir }}"
     owner: "root"
     group: "root"


### PR DESCRIPTION
- **OTHER CHANGES**
  - fix download URLs for Kubernetes binaries (see: [Download Kubernetes - Binaries](https://kubernetes.io/releases/download/#binaries)