### PR TITLE
31.0.0+1.34.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 31.0.0+1.34.4
+
+- **UPDATE**
+  - update `k8s_ctl_release` to `1.34.4`
+
+- **OTHER**
+  - replace injected `ansible_*` facts usage with `ansible_facts[...]` (prepares for ansible-core 2.24 where `INJECT_FACTS_AS_VARS` default changes)
+
+- **MOLECULE**
+  - use own [githubixx Vagrant boxes](https://portal.cloud.hashicorp.com/vagrant/discover/githubixx)
+  - add more checks in `verify.yml`
+
 ## 30.0.0+1.33.6
 
 - **UPDATE**

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Ansible role is used in [Kubernetes the not so hard way with Ansible - Work
 
 ## Versions
 
-I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `31.0.0+1.34.4` means this is release `31.0.0` of this role and it's meant to be used with Kubernetes version `1.34.4` (but should work with any K8s 1.33.x release of course). If the role itself changes `X.Y.Z` before `+` will increase. If the Kubernetes version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific Kubernetes release. That's especially useful for Kubernetes major releases with breaking changes.
+I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `31.0.0+1.34.4` means this is release `31.0.0` of this role and it's meant to be used with Kubernetes version `1.34.4` (but should work with any K8s 1.34.x release of course). If the role itself changes `X.Y.Z` before `+` will increase. If the Kubernetes version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific Kubernetes release. That's especially useful for Kubernetes major releases with breaking changes.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Ansible role is used in [Kubernetes the not so hard way with Ansible - Work
 
 ## Versions
 
-I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `30.0.0+1.33.6` means this is release `30.0.0` of this role and it's meant to be used with Kubernetes version `1.33.6` (but should work with any K8s 1.33.x release of course). If the role itself changes `X.Y.Z` before `+` will increase. If the Kubernetes version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific Kubernetes release. That's especially useful for Kubernetes major releases with breaking changes.
+I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `31.0.0+1.34.4` means this is release `31.0.0` of this role and it's meant to be used with Kubernetes version `1.34.4` (but should work with any K8s 1.33.x release of course). If the role itself changes `X.Y.Z` before `+` will increase. If the Kubernetes version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific Kubernetes release. That's especially useful for Kubernetes major releases with breaking changes.
 
 ## Requirements
 
@@ -26,6 +26,18 @@ See full [CHANGELOG.md](https://github.com/githubixx/ansible-role-kubernetes-wor
 **IMPORTANT** Version `24.0.0+1.27.8` had a lot of potential breaking changes. So if you upgrade from a version < `24.0.0+1.27.8` please read the CHANGELOG of that version too!
 
 **Recent changes:**
+
+## 31.0.0+1.34.4
+
+- **UPDATE**
+  - update `k8s_ctl_release` to `1.34.4`
+
+- **OTHER**
+  - replace injected `ansible_*` facts usage with `ansible_facts[...]` (prepares for ansible-core 2.24 where `INJECT_FACTS_AS_VARS` default changes)
+
+- **MOLECULE**
+  - use own [githubixx Vagrant boxes](https://portal.cloud.hashicorp.com/vagrant/discover/githubixx)
+  - add more checks in `verify.yml`
 
 ## 30.0.0+1.33.6
 
@@ -99,7 +111,7 @@ See full [CHANGELOG.md](https://github.com/githubixx/ansible-role-kubernetes-wor
 roles:
   - name: githubixx.kubernetes_worker
     src: https://github.com/githubixx/ansible-role-kubernetes-worker.git
-    version: 30.0.0+1.33.6
+    version: 31.0.0+1.34.4
 ```
 
 ## Role Variables
@@ -127,7 +139,7 @@ k8s_worker_pki_dir: "{{ k8s_worker_conf_dir }}/pki"
 k8s_worker_bin_dir: "/usr/local/bin"
 
 # K8s release
-k8s_worker_release: "1.33.6"
+k8s_worker_release: "1.34.4"
 
 # The interface on which the Kubernetes services should listen on. As all cluster
 # communication should use a VPN interface the interface name is
@@ -166,7 +178,7 @@ k8s_ca_conf_directory: "{{ '~/k8s/certs' | expanduser }}"
 # variable of https://github.com/githubixx/ansible-role-kubernetes-ca
 # role). If it's not specified you'll get certificate errors in the
 # logs of the services mentioned above.
-k8s_worker_api_endpoint_host: "{% set controller_host = groups['k8s_controller'][0] %}{{ hostvars[controller_host]['ansible_' + hostvars[controller_host]['k8s_interface']].ipv4.address }}"
+k8s_worker_api_endpoint_host: "{% set controller_host = groups['k8s_controller'][0] %}{{ hostvars[controller_host]['ansible_facts'][hostvars[controller_host]['k8s_interface']]['ipv4']['address'] }}"
 
 # As above just for the port. It specifies on which port the
 # Kubernetes API servers are listening. Again if there is a loadbalancer
@@ -203,14 +215,14 @@ k8s_worker_kubelet_conf_dir: "{{ k8s_worker_conf_dir }}/kubelet"
 # https://kubernetes.io/docs/tutorials/security/seccomp/#enable-the-use-of-runtimedefault-as-the-default-seccomp-profile-for-all-workloads
 k8s_worker_kubelet_settings:
   "config": "{{ k8s_worker_kubelet_conf_dir }}/kubelet-config.yaml"
-  "node-ip": "{{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}"
+  "node-ip": "{{ hostvars[inventory_hostname]['ansible_facts'][k8s_interface]['ipv4']['address'] }}"
   "kubeconfig": "{{ k8s_worker_kubelet_conf_dir }}/kubeconfig"
 
 # kubelet kubeconfig
 k8s_worker_kubelet_conf_yaml: |
   kind: KubeletConfiguration
   apiVersion: kubelet.config.k8s.io/v1beta1
-  address: {{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}
+  address: {{ hostvars[inventory_hostname]['ansible_facts'][k8s_interface]['ipv4']['address'] }}
   authentication:
     anonymous:
       enabled: false
@@ -224,7 +236,7 @@ k8s_worker_kubelet_conf_yaml: |
   clusterDNS:
     - "10.32.0.254"
   failSwapOn: true
-  healthzBindAddress: "{{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}"
+  healthzBindAddress: "{{ hostvars[inventory_hostname]['ansible_facts'][k8s_interface]['ipv4']['address'] }}"
   healthzPort: 10248
   runtimeRequestTimeout: "15m"
   serializeImagePulls: false
@@ -244,10 +256,10 @@ k8s_worker_kubeproxy_settings:
 k8s_worker_kubeproxy_conf_yaml: |
   kind: KubeProxyConfiguration
   apiVersion: kubeproxy.config.k8s.io/v1alpha1
-  bindAddress: {{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}
+  bindAddress: {{ hostvars[inventory_hostname]['ansible_facts'][k8s_interface]['ipv4']['address'] }}
   clientConnection:
     kubeconfig: "{{ k8s_worker_kubeproxy_conf_dir }}/kubeconfig"
-  healthzBindAddress: {{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}:10256
+  healthzBindAddress: {{ hostvars[inventory_hostname]['ansible_facts'][k8s_interface]['ipv4']['address'] }}:10256
   mode: "ipvs"
   ipvs:
     minSyncPeriod: 0s

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,7 @@ k8s_worker_pki_dir: "{{ k8s_worker_conf_dir }}/pki"
 k8s_worker_bin_dir: "/usr/local/bin"
 
 # K8s release
-k8s_worker_release: "1.33.6"
+k8s_worker_release: "1.34.4"
 
 # The interface on which the Kubernetes services should listen on. As all cluster
 # communication should use a VPN interface the interface name is
@@ -60,7 +60,7 @@ k8s_ca_conf_directory: "{{ '~/k8s/certs' | expanduser }}"
 # variable of https://github.com/githubixx/ansible-role-kubernetes-ca
 # role). If it's not specified you'll get certificate errors in the
 # logs of the services mentioned above.
-k8s_worker_api_endpoint_host: "{{ hostvars[groups['k8s_controller'] | first]['ansible_' + hostvars[groups['k8s_controller'] | first]['k8s_interface']].ipv4.address }}"
+k8s_worker_api_endpoint_host: "{{ hostvars[groups['k8s_controller'] | first]['ansible_facts'][hostvars[groups['k8s_controller'] | first]['k8s_interface']]['ipv4']['address'] }}"
 
 # As above just for the port. It specifies on which port the
 # Kubernetes API servers are listening. Again if there is a loadbalancer
@@ -97,14 +97,14 @@ k8s_worker_kubelet_conf_dir: "{{ k8s_worker_conf_dir }}/kubelet"
 # https://kubernetes.io/docs/tutorials/security/seccomp/#enable-the-use-of-runtimedefault-as-the-default-seccomp-profile-for-all-workloads
 k8s_worker_kubelet_settings:
   "config": "{{ k8s_worker_kubelet_conf_dir }}/kubelet-config.yaml"
-  "node-ip": "{{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}"
+  "node-ip": "{{ hostvars[inventory_hostname]['ansible_facts'][k8s_interface]['ipv4']['address'] }}"
   "kubeconfig": "{{ k8s_worker_kubelet_conf_dir }}/kubeconfig"
 
 # kubelet kubeconfig
 k8s_worker_kubelet_conf_yaml: |
   kind: KubeletConfiguration
   apiVersion: kubelet.config.k8s.io/v1beta1
-  address: {{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}
+  address: {{ hostvars[inventory_hostname]['ansible_facts'][k8s_interface]['ipv4']['address'] }}
   authentication:
     anonymous:
       enabled: false
@@ -118,7 +118,7 @@ k8s_worker_kubelet_conf_yaml: |
   clusterDNS:
     - "10.32.0.254"
   failSwapOn: true
-  healthzBindAddress: "{{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}"
+  healthzBindAddress: "{{ hostvars[inventory_hostname]['ansible_facts'][k8s_interface]['ipv4']['address'] }}"
   healthzPort: 10248
   runtimeRequestTimeout: "15m"
   serializeImagePulls: false
@@ -138,10 +138,10 @@ k8s_worker_kubeproxy_settings:
 k8s_worker_kubeproxy_conf_yaml: |
   kind: KubeProxyConfiguration
   apiVersion: kubeproxy.config.k8s.io/v1alpha1
-  bindAddress: {{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}
+  bindAddress: {{ hostvars[inventory_hostname]['ansible_facts'][k8s_interface]['ipv4']['address'] }}
   clientConnection:
     kubeconfig: "{{ k8s_worker_kubeproxy_conf_dir }}/kubeconfig"
-  healthzBindAddress: {{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}:10256
+  healthzBindAddress: {{ hostvars[inventory_hostname]['ansible_facts'][k8s_interface]['ipv4']['address'] }}:10256
   mode: "ipvs"
   ipvs:
     minSyncPeriod: 0s

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Robert Wimmer
   description: Installs Kubernetes worker.
   license: GPLv3
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.15"
   role_name: kubernetes_worker
   namespace: githubixx
   platforms:

--- a/molecule/default/group_vars/all.yml
+++ b/molecule/default/group_vars/all.yml
@@ -118,7 +118,7 @@ k8s_apiserver_settings_user:
 
 k8s_worker_kubelet_settings:
   "config": "{{ k8s_worker_kubelet_conf_dir }}/kubelet-config.yaml"
-  "node-ip": "{{ hostvars[inventory_hostname]['ansible_' + k8s_interface].ipv4.address }}"
+  "node-ip": "{{ hostvars[inventory_hostname]['ansible_facts'][k8s_interface]['ipv4']['address'] }}"
   "kubeconfig": "{{ k8s_worker_kubelet_conf_dir }}/kubeconfig"
   "seccomp-default": ""
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2023 Robert Wimmer
+# Copyright (C) 2023-2026 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 dependency:
@@ -13,7 +13,7 @@ driver:
 
 platforms:
   - name: test-assets
-    box: alvistack/ubuntu-22.04
+    box: githubixx/ubuntu-24.04
     memory: 2048
     cpus: 2
     groups:
@@ -26,7 +26,7 @@ platforms:
         type: static
         ip: 172.16.10.5
   - name: test-controller1
-    box: alvistack/ubuntu-22.04
+    box: githubixx/ubuntu-22.04
     memory: 2048
     cpus: 2
     groups:
@@ -41,7 +41,7 @@ platforms:
         type: static
         ip: 172.16.10.10
   - name: test-controller2
-    box: alvistack/ubuntu-22.04
+    box: githubixx/ubuntu-22.04
     memory: 2048
     cpus: 2
     groups:
@@ -56,7 +56,7 @@ platforms:
         type: static
         ip: 172.16.10.20
   - name: test-controller3
-    box: alvistack/ubuntu-24.04
+    box: githubixx/ubuntu-24.04
     memory: 2048
     cpus: 2
     groups:
@@ -70,7 +70,7 @@ platforms:
         type: static
         ip: 172.16.10.30
   - name: test-etcd1
-    box: alvistack/ubuntu-22.04
+    box: githubixx/ubuntu-24.04
     memory: 2048
     cpus: 2
     groups:
@@ -82,7 +82,7 @@ platforms:
         type: static
         ip: 172.16.10.100
   - name: test-etcd2
-    box: alvistack/ubuntu-22.04
+    box: githubixx/ubuntu-24.04
     memory: 2048
     cpus: 2
     groups:
@@ -94,7 +94,7 @@ platforms:
         type: static
         ip: 172.16.10.110
   - name: test-etcd3
-    box: alvistack/ubuntu-22.04
+    box: githubixx/ubuntu-24.04
     memory: 2048
     cpus: 2
     groups:
@@ -106,7 +106,7 @@ platforms:
         type: static
         ip: 172.16.10.120
   - name: test-worker1
-    box: alvistack/ubuntu-22.04
+    box: githubixx/ubuntu-22.04
     memory: 2048
     cpus: 2
     groups:
@@ -120,7 +120,7 @@ platforms:
         type: static
         ip: 172.16.10.200
   - name: test-worker2
-    box: alvistack/ubuntu-24.04
+    box: githubixx/ubuntu-24.04
     memory: 2048
     cpus: 2
     groups:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -21,6 +21,23 @@
         mode: "0640"
       - path: /etc/kubernetes/worker/kube-proxy/kubeconfig
         mode: "0640"
+    mol__worker_required_pki_files:
+      - path: /etc/kubernetes/worker/pki/ca-k8s-apiserver.pem
+        mode: "0640"
+      - path: /etc/kubernetes/worker/pki/ca-k8s-apiserver-key.pem
+        mode: "0640"
+      - path: /etc/kubernetes/worker/pki/cert-k8s-apiserver.pem
+        mode: "0640"
+      - path: /etc/kubernetes/worker/pki/cert-k8s-apiserver-key.pem
+        mode: "0640"
+      - path: /etc/kubernetes/worker/pki/cert-k8s-proxy.pem
+        mode: "0640"
+      - path: /etc/kubernetes/worker/pki/cert-k8s-proxy-key.pem
+        mode: "0640"
+      - path: "/etc/kubernetes/worker/pki/cert-{{ inventory_hostname }}.pem"
+        mode: "0640"
+      - path: "/etc/kubernetes/worker/pki/cert-{{ inventory_hostname }}-key.pem"
+        mode: "0640"
   tasks:
     - name: Gather service facts
       ansible.builtin.service_facts:
@@ -51,6 +68,19 @@
           - item.stat.exists
           - item.stat.mode == item.item.mode
       loop: "{{ mol__worker_required_file_stats.results }}"
+
+    - name: Gather worker PKI file metadata
+      ansible.builtin.stat:
+        path: "{{ item.path }}"
+      loop: "{{ mol__worker_required_pki_files }}"
+      register: mol__worker_required_pki_file_stats
+
+    - name: Ensure worker certificates/keys exist and have expected permissions
+      ansible.builtin.assert:
+        that:
+          - item.stat.exists
+          - item.stat.mode == item.item.mode
+      loop: "{{ mol__worker_required_pki_file_stats.results }}"
 
     - name: Read kubelet systemd unit file
       ansible.builtin.slurp:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -2,6 +2,56 @@
 # Copyright (C) 2023 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+- name: Verify worker services health
+  hosts: k8s_worker
+  remote_user: vagrant
+  become: true
+  gather_facts: false
+  vars:
+    mol__worker_required_files:
+      - path: /etc/systemd/system/kubelet.service
+        mode: "0644"
+      - path: /etc/systemd/system/kube-proxy.service
+        mode: "0644"
+      - path: /etc/kubernetes/worker/kubelet/kubelet-config.yaml
+        mode: "0600"
+      - path: /etc/kubernetes/worker/kube-proxy/kubeproxy-config.yaml
+        mode: "0600"
+      - path: /etc/kubernetes/worker/kubelet/kubeconfig
+        mode: "0640"
+      - path: /etc/kubernetes/worker/kube-proxy/kubeconfig
+        mode: "0640"
+  tasks:
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
+    - name: Ensure kubelet service is running and enabled
+      ansible.builtin.assert:
+        that:
+          - "'kubelet.service' in ansible_facts.services"
+          - ansible_facts.services['kubelet.service'].state == 'running'
+          - ansible_facts.services['kubelet.service'].status == 'enabled'
+
+    - name: Ensure kube-proxy service is running and enabled
+      ansible.builtin.assert:
+        that:
+          - "'kube-proxy.service' in ansible_facts.services"
+          - ansible_facts.services['kube-proxy.service'].state == 'running'
+          - ansible_facts.services['kube-proxy.service'].status == 'enabled'
+
+    - name: Gather required file metadata
+      ansible.builtin.stat:
+        path: "{{ item.path }}"
+      loop: "{{ mol__worker_required_files }}"
+      register: mol__worker_required_file_stats
+
+    - name: Ensure required files exist and have expected permissions
+      ansible.builtin.assert:
+        that:
+          - item.stat.exists
+          - item.stat.mode == item.item.mode
+      loop: "{{ mol__worker_required_file_stats.results }}"
+
 - name: Verify setup
   hosts: test-assets
   remote_user: vagrant

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -38,6 +38,27 @@
         mode: "0640"
       - path: "/etc/kubernetes/worker/pki/cert-{{ inventory_hostname }}-key.pem"
         mode: "0640"
+    mol__worker_sensitive_auth_files:
+      - path: /etc/kubernetes/worker/kubelet/kubeconfig
+        mode: "0640"
+      - path: /etc/kubernetes/worker/kube-proxy/kubeconfig
+        mode: "0640"
+      - path: /etc/kubernetes/worker/pki/ca-k8s-apiserver.pem
+        mode: "0640"
+      - path: /etc/kubernetes/worker/pki/ca-k8s-apiserver-key.pem
+        mode: "0640"
+      - path: /etc/kubernetes/worker/pki/cert-k8s-apiserver.pem
+        mode: "0640"
+      - path: /etc/kubernetes/worker/pki/cert-k8s-apiserver-key.pem
+        mode: "0640"
+      - path: /etc/kubernetes/worker/pki/cert-k8s-proxy.pem
+        mode: "0640"
+      - path: /etc/kubernetes/worker/pki/cert-k8s-proxy-key.pem
+        mode: "0640"
+      - path: "/etc/kubernetes/worker/pki/cert-{{ inventory_hostname }}.pem"
+        mode: "0640"
+      - path: "/etc/kubernetes/worker/pki/cert-{{ inventory_hostname }}-key.pem"
+        mode: "0640"
   tasks:
     - name: Gather service facts
       ansible.builtin.service_facts:
@@ -81,6 +102,22 @@
           - item.stat.exists
           - item.stat.mode == item.item.mode
       loop: "{{ mol__worker_required_pki_file_stats.results }}"
+
+    - name: Gather metadata for sensitive auth files
+      ansible.builtin.stat:
+        path: "{{ item.path }}"
+      loop: "{{ mol__worker_sensitive_auth_files }}"
+      register: mol__worker_sensitive_auth_file_stats
+
+    - name: Ensure sensitive auth files are root-owned and not world-readable
+      ansible.builtin.assert:
+        that:
+          - item.stat.exists
+          - item.stat.mode == item.item.mode
+          - item.stat.pw_name == 'root'
+          - item.stat.gr_name == 'root'
+          - item.stat.mode[3] == '0'
+      loop: "{{ mol__worker_sensitive_auth_file_stats.results }}"
 
     - name: Read kubelet systemd unit file
       ansible.builtin.slurp:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -52,6 +52,43 @@
           - item.stat.mode == item.item.mode
       loop: "{{ mol__worker_required_file_stats.results }}"
 
+    - name: Read kubelet systemd unit file
+      ansible.builtin.slurp:
+        src: /etc/systemd/system/kubelet.service
+      register: mol__kubelet_unit
+
+    - name: Read kube-proxy systemd unit file
+      ansible.builtin.slurp:
+        src: /etc/systemd/system/kube-proxy.service
+      register: mol__kubeproxy_unit
+
+    - name: Ensure kubelet unit uses role-managed config paths
+      ansible.builtin.assert:
+        that:
+          - "'--config=/etc/kubernetes/worker/kubelet/kubelet-config.yaml' in (mol__kubelet_unit.content | b64decode)"
+          - "'--kubeconfig=/etc/kubernetes/worker/kubelet/kubeconfig' in (mol__kubelet_unit.content | b64decode)"
+
+    - name: Ensure kube-proxy unit uses role-managed config path
+      ansible.builtin.assert:
+        that:
+          - "'--config=/etc/kubernetes/worker/kube-proxy/kubeproxy-config.yaml' in (mol__kubeproxy_unit.content | b64decode)"
+
+    - name: Read kube-proxy config
+      ansible.builtin.slurp:
+        src: /etc/kubernetes/worker/kube-proxy/kubeproxy-config.yaml
+      register: mol__kubeproxy_config_raw
+
+    - name: Parse kube-proxy config
+      ansible.builtin.set_fact:
+        mol__kubeproxy_config: "{{ mol__kubeproxy_config_raw.content | b64decode | from_yaml }}"
+
+    - name: Ensure kube-proxy role configuration is applied
+      ansible.builtin.assert:
+        that:
+          - mol__kubeproxy_config.kind == 'KubeProxyConfiguration'
+          - mol__kubeproxy_config.apiVersion == 'kubeproxy.config.k8s.io/v1alpha1'
+          - mol__kubeproxy_config.clientConnection.kubeconfig == '/etc/kubernetes/worker/kube-proxy/kubeconfig'
+
 - name: Verify setup
   hosts: test-assets
   remote_user: vagrant

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -80,3 +80,34 @@
       ansible.builtin.assert:
         that:
           - k8s__namespaces_count|int >= 4
+
+    - name: Fetch node information
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Node
+        kubeconfig: "{{ k8s_admin_conf_dir }}/admin.kubeconfig"
+      register: k8s__nodes_info
+
+    - name: Register node names
+      ansible.builtin.set_fact:
+        k8s__node_names: "{{ k8s__nodes_info | community.general.json_query(mol__query) }}"
+      vars:
+        mol__query: "resources[].metadata.name"
+
+    - name: Register ready node names
+      ansible.builtin.set_fact:
+        k8s__node_ready_names: "{{ k8s__nodes_info | community.general.json_query(mol__query) }}"
+      vars:
+        mol__query: "resources[?status.conditions[?type=='Ready' && status=='True']].metadata.name"
+
+    - name: Ensure all expected worker nodes joined cluster
+      ansible.builtin.assert:
+        that:
+          - item in k8s__node_names
+      loop: "{{ groups['k8s_worker'] }}"
+
+    - name: Ensure all expected worker nodes are Ready
+      ansible.builtin.assert:
+        that:
+          - item in k8s__node_ready_names
+      loop: "{{ groups['k8s_worker'] }}"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -78,9 +78,30 @@
         src: /etc/kubernetes/worker/kube-proxy/kubeproxy-config.yaml
       register: mol__kubeproxy_config_raw
 
+    - name: Read kubelet config
+      ansible.builtin.slurp:
+        src: /etc/kubernetes/worker/kubelet/kubelet-config.yaml
+      register: mol__kubelet_config_raw
+
     - name: Parse kube-proxy config
       ansible.builtin.set_fact:
         mol__kubeproxy_config: "{{ mol__kubeproxy_config_raw.content | b64decode | from_yaml }}"
+
+    - name: Parse kubelet config
+      ansible.builtin.set_fact:
+        mol__kubelet_config: "{{ mol__kubelet_config_raw.content | b64decode | from_yaml }}"
+
+    - name: Ensure kubelet role configuration is applied
+      ansible.builtin.assert:
+        that:
+          - mol__kubelet_config.kind == 'KubeletConfiguration'
+          - mol__kubelet_config.apiVersion == 'kubelet.config.k8s.io/v1beta1'
+          - mol__kubelet_config.authentication.x509.clientCAFile == '/etc/kubernetes/worker/pki/ca-k8s-apiserver.pem'
+          - mol__kubelet_config.healthzPort == 10248
+          - mol__kubelet_config.containerRuntimeEndpoint == 'unix:///run/containerd/containerd.sock'
+          - mol__kubelet_config.cgroupDriver is defined
+          - mol__kubelet_config.tlsCertFile == '/etc/kubernetes/worker/pki/cert-' + inventory_hostname + '.pem'
+          - mol__kubelet_config.tlsPrivateKeyFile == '/etc/kubernetes/worker/pki/cert-' + inventory_hostname + '-key.pem'
 
     - name: Ensure kube-proxy role configuration is applied
       ansible.builtin.assert:
@@ -88,6 +109,7 @@
           - mol__kubeproxy_config.kind == 'KubeProxyConfiguration'
           - mol__kubeproxy_config.apiVersion == 'kubeproxy.config.k8s.io/v1alpha1'
           - mol__kubeproxy_config.clientConnection.kubeconfig == '/etc/kubernetes/worker/kube-proxy/kubeconfig'
+          - mol__kubeproxy_config.mode is defined
 
 - name: Verify setup
   hosts: test-assets

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -111,6 +111,54 @@
           - mol__kubeproxy_config.clientConnection.kubeconfig == '/etc/kubernetes/worker/kube-proxy/kubeconfig'
           - mol__kubeproxy_config.mode is defined
 
+    - name: Load role default variables
+      ansible.builtin.include_vars:
+        file: "../../defaults/main.yml"
+        name: mol__role_defaults
+
+    - name: Register expected Kubernetes version from role defaults
+      ansible.builtin.set_fact:
+        mol__expected_k8s_version: "v{{ mol__role_defaults.k8s_worker_release }}"
+
+    - name: Fetch kubelet version
+      ansible.builtin.command:
+        argv:
+          - kubelet
+          - --version
+      register: mol__kubelet_version_cmd
+      changed_when: false
+
+    - name: Fetch kube-proxy version
+      ansible.builtin.command:
+        argv:
+          - kube-proxy
+          - --version
+      register: mol__kubeproxy_version_cmd
+      changed_when: false
+
+    - name: Fetch kubectl client version
+      ansible.builtin.command:
+        argv:
+          - kubectl
+          - version
+          - --client
+          - --output=json
+      register: mol__kubectl_version_cmd
+      changed_when: false
+
+    - name: Parse binary versions
+      ansible.builtin.set_fact:
+        mol__kubelet_version: "{{ mol__kubelet_version_cmd.stdout | regex_search('v[0-9]+\\.[0-9]+\\.[0-9]+') }}"
+        mol__kubeproxy_version: "{{ mol__kubeproxy_version_cmd.stdout | regex_search('v[0-9]+\\.[0-9]+\\.[0-9]+') }}"
+        mol__kubectl_version: "{{ (mol__kubectl_version_cmd.stdout | from_json).clientVersion.gitVersion }}"
+
+    - name: Ensure worker binary versions match role release
+      ansible.builtin.assert:
+        that:
+          - mol__kubelet_version == mol__expected_k8s_version
+          - mol__kubeproxy_version == mol__expected_k8s_version
+          - mol__kubectl_version == mol__expected_k8s_version
+
 - name: Verify setup
   hosts: test-assets
   remote_user: vagrant

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -81,33 +81,30 @@
         that:
           - k8s__namespaces_count|int >= 4
 
-    - name: Fetch node information
-      kubernetes.core.k8s_info:
-        api_version: v1
-        kind: Node
-        kubeconfig: "{{ k8s_admin_conf_dir }}/admin.kubeconfig"
-      register: k8s__nodes_info
-
-    - name: Register node names
-      ansible.builtin.set_fact:
-        k8s__node_names: "{{ k8s__nodes_info | community.general.json_query(mol__query) }}"
-      vars:
-        mol__query: "resources[].metadata.name"
-
-    - name: Register ready node names
-      ansible.builtin.set_fact:
-        k8s__node_ready_names: "{{ k8s__nodes_info | community.general.json_query(mol__query) }}"
-      vars:
-        mol__query: "resources[?status.conditions[?type=='Ready' && status=='True']].metadata.name"
-
-    - name: Ensure all expected worker nodes joined cluster
-      ansible.builtin.assert:
-        that:
-          - item in k8s__node_names
+    - name: Ensure all expected worker nodes appear in kubectl get nodes
+      ansible.builtin.command: >
+        kubectl --kubeconfig {{ k8s_admin_conf_dir }}/admin.kubeconfig get node {{ item }} --no-headers
       loop: "{{ groups['k8s_worker'] }}"
+      changed_when: false
+
+    - name: Fetch worker node Ready condition from kubectl
+      ansible.builtin.command:
+        argv:
+          - kubectl
+          - --kubeconfig
+          - "{{ k8s_admin_conf_dir }}/admin.kubeconfig"
+          - get
+          - node
+          - "{{ item }}"
+          - -o
+          - 'jsonpath={.status.conditions[?(@.type=="Ready")].status}'
+      loop: "{{ groups['k8s_worker'] }}"
+      register: mol__kubectl_node_ready
+      changed_when: false
 
     - name: Ensure all expected worker nodes are Ready
       ansible.builtin.assert:
         that:
-          - item in k8s__node_ready_names
-      loop: "{{ groups['k8s_worker'] }}"
+          - item.stdout == "True"
+        fail_msg: "Worker node {{ item.item }} is not Ready"
+      loop: "{{ mol__kubectl_node_ready.results }}"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -229,6 +229,10 @@
 - name: Verify setup
   hosts: test-assets
   remote_user: vagrant
+  vars:
+    mol__smoke_namespace: "molecule-smoke"
+    mol__smoke_app_name: "nginx-smoke"
+    mol__run_scheduling_check: false
   tasks:
     - name: Fetch namespaces information
       kubernetes.core.k8s_info:
@@ -282,3 +286,200 @@
           - item.stdout == "True"
         fail_msg: "Worker node {{ item.item }} is not Ready"
       loop: "{{ mol__kubectl_node_ready.results }}"
+
+    - name: Detect Cilium DaemonSet readiness
+      ansible.builtin.command:
+        argv:
+          - kubectl
+          - --kubeconfig
+          - "{{ k8s_admin_conf_dir }}/admin.kubeconfig"
+          - -n
+          - cilium
+          - get
+          - daemonset
+          - cilium
+          - -o
+          - jsonpath={.status.numberReady}/{.status.desiredNumberScheduled}
+      register: mol__cilium_daemonset_status
+      changed_when: false
+      failed_when: false
+
+    - name: Register whether smoke tests should run
+      ansible.builtin.set_fact:
+        mol__run_smoke_tests: >-
+          {{
+            mol__cilium_daemonset_status.rc == 0
+            and (mol__cilium_daemonset_status.stdout | trim) is match('^[0-9]+/[0-9]+$')
+            and ((mol__cilium_daemonset_status.stdout | trim).split('/')[1] | int) > 0
+            and ((mol__cilium_daemonset_status.stdout | trim).split('/')[0] | int) == ((mol__cilium_daemonset_status.stdout | trim).split('/')[1] | int)
+          }}
+
+    - name: Show smoke-test gating status
+      ansible.builtin.debug:
+        msg: >-
+          Cilium ready={{ mol__run_smoke_tests }} (raw status: {{ mol__cilium_daemonset_status.stdout | default('n/a') | trim }})
+      when: ansible_verbosity > 0
+
+    - name: Run workload smoke tests when networking is installed
+      when: mol__run_smoke_tests | bool
+      block:
+        - name: Ensure old smoke-test resources are absent
+          ansible.builtin.command:
+            argv:
+              - kubectl
+              - --kubeconfig
+              - "{{ k8s_admin_conf_dir }}/admin.kubeconfig"
+              - delete
+              - namespace
+              - "{{ mol__smoke_namespace }}"
+              - --ignore-not-found=true
+              - --wait=true
+              - --timeout=180s
+          changed_when: false
+
+        - name: Ensure smoke-test namespace exists
+          ansible.builtin.command:
+            argv:
+              - kubectl
+              - --kubeconfig
+              - "{{ k8s_admin_conf_dir }}/admin.kubeconfig"
+              - apply
+              - -f
+              - '-'
+          changed_when: false
+          args:
+            stdin: |
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: {{ mol__smoke_namespace }}
+
+        - name: Deploy nginx smoke workload and ClusterIP service
+          ansible.builtin.command:
+            argv:
+              - kubectl
+              - --kubeconfig
+              - "{{ k8s_admin_conf_dir }}/admin.kubeconfig"
+              - apply
+              - -f
+              - '-'
+          changed_when: false
+          args:
+            stdin: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: {{ mol__smoke_app_name }}
+                namespace: {{ mol__smoke_namespace }}
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    app: {{ mol__smoke_app_name }}
+                template:
+                  metadata:
+                    labels:
+                      app: {{ mol__smoke_app_name }}
+                  spec:
+                    containers:
+                      - name: nginx
+                        image: nginx:1.27-alpine
+                        ports:
+                          - containerPort: 80
+              ---
+              apiVersion: v1
+              kind: Service
+              metadata:
+                name: {{ mol__smoke_app_name }}
+                namespace: {{ mol__smoke_namespace }}
+              spec:
+                type: ClusterIP
+                selector:
+                  app: {{ mol__smoke_app_name }}
+                ports:
+                  - port: 80
+                    targetPort: 80
+                    protocol: TCP
+
+        - name: Wait for nginx smoke deployment rollout
+          ansible.builtin.command:
+            argv:
+              - kubectl
+              - --kubeconfig
+              - "{{ k8s_admin_conf_dir }}/admin.kubeconfig"
+              - -n
+              - "{{ mol__smoke_namespace }}"
+              - rollout
+              - status
+              - "deployment/{{ mol__smoke_app_name }}"
+              - --timeout=180s
+          changed_when: false
+
+        - name: Wait for nginx smoke service endpoints
+          ansible.builtin.command:
+            argv:
+              - kubectl
+              - --kubeconfig
+              - "{{ k8s_admin_conf_dir }}/admin.kubeconfig"
+              - -n
+              - "{{ mol__smoke_namespace }}"
+              - get
+              - endpoints
+              - "{{ mol__smoke_app_name }}"
+              - -o
+              - jsonpath={.subsets[*].addresses[*].ip}
+          register: mol__smoke_endpoints
+          changed_when: false
+          retries: 18
+          delay: 10
+          until: (mol__smoke_endpoints.stdout | trim) != ''
+
+        - name: In-cluster HTTP check against nginx smoke service DNS
+          ansible.builtin.command:
+            argv:
+              - kubectl
+              - --kubeconfig
+              - "{{ k8s_admin_conf_dir }}/admin.kubeconfig"
+              - -n
+              - "{{ mol__smoke_namespace }}"
+              - run
+              - smoke-curl
+              - --image=curlimages/curl:8.12.1
+              - --restart=Never
+              - --rm
+              - --attach
+              - --command
+              - --
+              - sh
+              - -ec
+              - >-
+                code="$(curl -sS -o /dev/null -w '%{http_code}'
+                'http://{{ mol__smoke_app_name }}.{{ mol__smoke_namespace }}.svc.cluster.local')";
+                test "$code" = "200"
+          changed_when: false
+
+        - name: Fetch node names for nginx smoke pods
+          when: mol__run_scheduling_check | bool
+          ansible.builtin.command:
+            argv:
+              - kubectl
+              - --kubeconfig
+              - "{{ k8s_admin_conf_dir }}/admin.kubeconfig"
+              - -n
+              - "{{ mol__smoke_namespace }}"
+              - get
+              - pod
+              - -l
+              - "app={{ mol__smoke_app_name }}"
+              - -o
+              - jsonpath={.items[*].spec.nodeName}
+          register: mol__smoke_pod_node_names
+          changed_when: false
+
+        - name: Ensure nginx smoke pods are scheduled on worker nodes (optional)
+          when: mol__run_scheduling_check | bool
+          ansible.builtin.assert:
+            that:
+              - item in groups['k8s_worker']
+            fail_msg: "Smoke pod scheduled on unexpected node {{ item }}"
+          loop: "{{ mol__smoke_pod_node_names.stdout.split() }}"

--- a/tasks/authconfig/kubelet.yml
+++ b/tasks/authconfig/kubelet.yml
@@ -26,7 +26,7 @@
 - name: Generate kubeconfig for kubelet (set-credentials)
   ansible.builtin.shell: >
     set -o errexit; \
-    kubectl config set-credentials system:node:{{ ansible_hostname }} \
+    kubectl config set-credentials system:node:{{ ansible_facts['hostname'] }} \
       --client-certificate={{ k8s_worker_pki_dir }}/cert-{{ inventory_hostname }}.pem \
       --client-key={{ k8s_worker_pki_dir }}/cert-{{ inventory_hostname }}-key.pem \
       --embed-certs=true \
@@ -47,7 +47,7 @@
     set -o errexit; \
     kubectl config set-context default \
       --cluster={{ k8s_config_cluster_name }} \
-      --user=system:node:{{ ansible_hostname }} \
+      --user=system:node:{{ ansible_facts['hostname'] }} \
       --kubeconfig={{ k8s_worker_kubelet_conf_dir }}/kubeconfig
   args:
     executable: /bin/bash

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Disable swap
   ansible.builtin.command: swapoff -a
-  when: ansible_swaptotal_mb > 0
+  when: ansible_facts['swaptotal_mb'] > 0
   changed_when: false
   tags:
     - k8s-worker


### PR DESCRIPTION
- **UPDATE**
  - update `k8s_ctl_release` to `1.34.4`

- **OTHER**
  - replace injected `ansible_*` facts usage with `ansible_facts[...]` (prepares for ansible-core 2.24 where `INJECT_FACTS_AS_VARS` default changes)

- **MOLECULE**
  - use own [githubixx Vagrant boxes](https://portal.cloud.hashicorp.com/vagrant/discover/githubixx)
  - add more checks in `verify.yml`
